### PR TITLE
[Actions] Auto-Update dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: check-ast
       - id: check-added-large-files


### PR DESCRIPTION
The following packages are outdated

| Package            | Used   | Update   |
|--------------------|--------|----------|
| importlib-metadata | 4.2.0  | 4.10.0   |
| markdown           | 3.3.5  | 3.3.6    |
| pytkdocs           | 0.9.0  | 0.14.2   |
| tomli              | 1.2.3  | 2.0.0    |
| tryceratops        | 0.1    | 1.0.0    |